### PR TITLE
Enable scratch encryption and increase swap RAM buffer

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -45,7 +45,9 @@
             "mcuboot.signature-algorithm": "SIGNATURE_TYPE_EC256",
             "mcuboot.encrypt-ec256": true,
             "mcuboot.include-keys": null,
-            "mcuboot.bootloader-build": false
+            "mcuboot.bootloader-build": false,
+            "mcuboot.encrypt-scratch": true,
+            "mcuboot.swap-buf-size": 131072
         }
     }
 }


### PR DESCRIPTION
These are two experimental features that might need some additional work in future.

* mcuboot.encrypt-scratch: true -> enables scratch encryption
During a swap when movig data from slot 1 to scratch data is decrypted taking care of slot 1 offsets. This is the default MCUboot behaviour.  This features enables re-encryption of this data before writing it into scratch and decryption before writing scratch data into slot 0.

* mcuboot.swap-buf-size: 131072 -> swap buffer size
During a swap data is normally readed from flash and store into a 1K buffer to encrypt/decrypt and moving the data. Increasing the size of the buffer improves swap time. Swapping 1MB of data with 1KB buffer takes 5' using 128KB buffer takes 3'2''