### PR TITLE
Add fflush after program and erase operations

### DIFF
--- a/app/fileblockdevice/FileBlockDevice.cpp
+++ b/app/fileblockdevice/FileBlockDevice.cpp
@@ -121,6 +121,12 @@ int FileBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
         return BD_ERROR_DEVICE_ERROR;
     }
 
+    err = fflush(_file[0]);
+    if (err != 0u) {
+        printf("E-Program:flush\n");
+        return BD_ERROR_DEVICE_ERROR;
+    }
+
     return BD_ERROR_OK;
 }
 
@@ -146,6 +152,12 @@ int FileBlockDevice::erase(bd_addr_t addr, bd_size_t size)
             printf("E-Erase:handle %d count 0x%zx\n", _file[0], count);
             return BD_ERROR_DEVICE_ERROR;
         }
+    }
+
+    int err = fflush(_file[0]);
+    if (err != 0u) {
+        printf("E-Erase:flush\n");
+        return BD_ERROR_DEVICE_ERROR;
     }
 
     return BD_ERROR_OK;


### PR DESCRIPTION
 This is needed to keep the file in sync during swap operations if reset occurs, because the file is closed only at the end of the swap process.