### PR TITLE
Report only board name in usb descriptor

### DIFF
--- a/app/board.h
+++ b/app/board.h
@@ -82,7 +82,7 @@
   #define BOARD_USBD_VID                      0x2341
   #define BOARD_USBD_PID                      0x035B
 
-  #define BOARD_USBD_STRING                   "Portenta H7 MCUboot"
+  #define BOARD_USBD_STRING                   "Portenta H7"
 
   #define BOARD_QSPI_SO0                      PD_11
   #define BOARD_QSPI_SO1                      PD_12
@@ -149,7 +149,7 @@
   #define BOARD_USBD_VID                      0x2341
   #define BOARD_USBD_PID                      0x035F
 
-  #define BOARD_USBD_STRING                   "Nicla Vision MCUboot"
+  #define BOARD_USBD_STRING                   "Nicla Vision"
 
   #define BOARD_QSPI_SO0                      PD_11
   #define BOARD_QSPI_SO1                      PF_9


### PR DESCRIPTION
Distinction between standard bootloader and MCUboot is available using dfu-util --list. 

See: https://github.com/arduino/mcuboot-arduino-stm32h7/pull/21